### PR TITLE
[fix] main page에서만 조회수, 좋아요가 반영되던 버그 수정

### DIFF
--- a/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionView.swift
+++ b/iOS/Macro/Macro/Common/UI/PostCollectionView/PostCollectionView.swift
@@ -55,7 +55,26 @@ private extension PostCollectionView {
             default: break
             }
         }.store(in: &cancellables)
-    }
+        
+        readViewDisappear
+                .sink { [weak self] updatedPost in
+                    self?.reloadCellForReadPost(updatedPost)
+                }
+                .store(in: &cancellables)
+        }
+
+        func reloadCellForReadPost(_ readPost: ReadPost) {
+            guard let index = viewModel.posts.firstIndex(where: { $0.postId == readPost.postId }) else { return }
+            
+            viewModel.posts[index].likeNum = readPost.likeNum
+                viewModel.posts[index].liked = readPost.liked
+                viewModel.posts[index].viewNum = readPost.viewNum
+            let indexPath = IndexPath(item: index, section: 0)
+            DispatchQueue.main.async {
+                self.reloadItems(at: [indexPath])
+            }
+            
+        }
 }
 
 // MARK: - Methods


### PR DESCRIPTION


## 설명 📄

[fix] main page에서만 조회수, 좋아요가 반영되던 버그 수정
컬렉션뷰의 셀 하나만 다시 리로드했습니다.