### PR TITLE
[fix] 코어데이터 컬렉션뷰 재사용 문제 해결, 경로 기록 관련 개선

### DIFF
--- a/iOS/Macro/Macro/Common/UI/MapCollectionView/MapCollectionViewCellContentView.swift
+++ b/iOS/Macro/Macro/Common/UI/MapCollectionView/MapCollectionViewCellContentView.swift
@@ -16,6 +16,7 @@ final class MapCollectionViewCellContentView<T: MapCollectionViewProtocol>: UIVi
     var viewModel: T?
     var travelInfo: TravelInfo?
     private var routeOverlay: NMFPath?
+    private var markers: [NMFMarker] = []
     
     // MARK: - UI Components
     
@@ -141,6 +142,8 @@ extension MapCollectionViewCellContentView {
     
     func configure(item: TravelInfo) {
         self.travelInfo = item
+        markers.forEach { $0.mapView = nil }
+        markers.removeAll()
         
         guard let start = item.startAt, let end = item.endAt else { return }
         self.title.text = "\(Date.transDate(start)) ~ \(Date.transDate(end))"
@@ -157,8 +160,10 @@ extension MapCollectionViewCellContentView {
         updateMapWithLocation(routePoints: recordedLocation)
         
         guard let recordedPinnedInfo = item.recordedPinnedLocations else { return }
+        if let recordedPinnedInfo = item.recordedPinnedLocations {
+            updateMark(recordedPindedInfo: recordedPinnedInfo)
+        }
         
-        updateMark(recordedPindedInfo: recordedPinnedInfo)
     }
     
     /// Center 좌표를 센터값을 구하고, 좌표간 거리를 기반으로 Zoom Level을 설정합니다.
@@ -217,7 +222,7 @@ extension MapCollectionViewCellContentView {
         let zoomLevelLongitude = log2(90 / distanceLongitude)
         let zoomLevel = min(min(zoomLevelLatitude, zoomLevelLongitude), 15)
         mapView.zoomLevel = zoomLevel
-       
+        
         let cameraUpdate = NMFCameraUpdate(scrollTo: centerLocation )
         mapView.moveCamera(cameraUpdate)
     }
@@ -244,6 +249,7 @@ extension MapCollectionViewCellContentView {
             marker.position = NMGLatLng(lat: placeLocation.latitude, lng: placeLocation.longitude)
             marker.captionText = "\(index + 1). \(name)"
             marker.mapView = mapView
+            markers.append(marker)
         }
     }
 }

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/TravelViewController.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/View/TravelViewController.swift
@@ -268,6 +268,8 @@ extension TravelViewController {
                 self?.moveCameraToCoordinates(latitude: mapY, longitude: mapX)
             case .removeMapLocation:
                 self?.removeMapLocation()
+            case .breakRecord:
+                self?.breakRecord()
             default: break
             }
         }.store(in: &cancellables)
@@ -431,6 +433,17 @@ extension TravelViewController {
             .show()
     }
     
+    private func breakRecord() {
+        AlertBuilder(viewController: self)
+            .setTitle("기록 중지")
+            .setMessage("장시간 기록으로, 기록을 중지합니다.")
+            .addActionConfirm("확인") {
+            }
+            .show()
+        self.inputSubject.send(.endTravel)
+        self.isTraveling = false
+    }
+    
 }
 
 // MARK: - Methods
@@ -542,7 +555,7 @@ extension TravelViewController {
     }
     
     func mapView(_ mapView: NMFMapView, didTapMap latLng: NMGLatLng, point: CGPoint) {
-         self.view.endEditing(true)
-     }
+        self.view.endEditing(true)
+    }
     
 }

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
@@ -110,13 +110,13 @@ extension TravelViewModel {
                .sink { [weak self] location in
                 guard let self = self else { return }
                 guard let location = location else { return }
-                print(savedRoute.routePoints.count)
+                
                 if self.savedRoute.routePoints.isEmpty {
                     self.savedRoute.routePoints.append(contentsOf: [location, location])
                     self.outputSubject.send(.updateRoute(location))
                 }
                 else if self.savedRoute.routePoints.last == location { }
-                else if self.savedRoute.routePoints.count >= 7000 {
+                else if self.savedRoute.routePoints.count >= 10000 {
                     self.outputSubject.send(.breakRecord)
                 }
                 else {

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
@@ -19,6 +19,7 @@ final class TravelViewModel: ViewModelProtocol {
     private let locationSearcher: SearchUseCase
     private let pinnedPlaceManager: PinnedPlaceManageUseCase
     private var cancellables = Set<AnyCancellable>()
+    private var locationSubscription: AnyCancellable?
     private (set) var savedRoute: SavedRoute = SavedRoute()
     private (set) var searchedResult: [LocationDetail] = [] {
         didSet {
@@ -53,6 +54,7 @@ final class TravelViewModel: ViewModelProtocol {
         case moveCamera(Double, Double)
         case removeMapLocation
         case transViewBySearchedResultCount(Bool)
+        case breakRecord
     }
     
     // MARK: - Init
@@ -101,22 +103,28 @@ extension TravelViewModel {
          routeRecorder.startRecording()
          routeRecorder.locationPublisher
          */
-        generateTravel()
-        LocationManager.shared.startRecording()
-        LocationManager.shared.locationPublisher
-            .sink { [weak self] location in
+        locationSubscription?.cancel() // 이전 구독 취소
+           generateTravel()
+           LocationManager.shared.startRecording()
+           locationSubscription = LocationManager.shared.locationPublisher
+               .sink { [weak self] location in
                 guard let self = self else { return }
                 guard let location = location else { return }
+                print(savedRoute.routePoints.count)
                 if self.savedRoute.routePoints.isEmpty {
                     self.savedRoute.routePoints.append(contentsOf: [location, location])
+                    self.outputSubject.send(.updateRoute(location))
                 }
                 else if self.savedRoute.routePoints.last == location { }
+                else if self.savedRoute.routePoints.count >= 7000 {
+                    self.outputSubject.send(.breakRecord)
+                }
                 else {
                     self.savedRoute.routePoints.append(location)
+                    self.outputSubject.send(.updateRoute(location))
                 }
-                self.outputSubject.send(.updateRoute(location))
             }
-            .store(in: &cancellables)
+            
     }
     
     private func generateTravel() {
@@ -146,6 +154,8 @@ extension TravelViewModel {
     
         LocationManager.shared.stopRecording()
         savedRoute = SavedRoute()
+        locationSubscription?.cancel() 
+            locationSubscription = nil
         outputSubject.send(.removeMapLocation)
         outputSubject.send(.updatePinnedPlacesTableView)
     }

--- a/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
+++ b/iOS/Macro/Macro/Scene/Travel/InterfaceAdapters/ViewModel/TravelViewModel.swift
@@ -110,6 +110,7 @@ extension TravelViewModel {
                 if self.savedRoute.routePoints.isEmpty {
                     self.savedRoute.routePoints.append(contentsOf: [location, location])
                 }
+                else if self.savedRoute.routePoints.last == location { }
                 else {
                     self.savedRoute.routePoints.append(location)
                 }


### PR DESCRIPTION
## 개요 📖

코어데이터 컬렉션뷰 재사용 문제 해결 필요

## 설명 📄

1. 코어데이터 컬렉션뷰 재사용 문제 해결
2. 경로 기록 좌표 개수 맥시멈 10000개로 지정. 그 이상 넘어가면 기록 강제 중지.
3. 만약 5초전 내 좌표와 현재 좌표가 일치하면, 그 좌표는 추가시켜주지 않도록 로직 추가


